### PR TITLE
Update deprecated array syntax

### DIFF
--- a/inst/stan/NB.stan
+++ b/inst/stan/NB.stan
@@ -17,7 +17,7 @@
 data {
   int N;                // Number of observations
   int K;                // Number of covariates
-  int y[N];             // Outcome variable
+  array[N] int y;             // Outcome variable
   matrix[N, K] X;       // Model matrix
   vector[N] treat;      // Treatment indicator
   real tau_mean;        // Prior mean for treatment effect

--- a/inst/stan/hurdlelognormal.stan
+++ b/inst/stan/hurdlelognormal.stan
@@ -17,7 +17,7 @@
 data {
   // Data dimensions
   int<lower=0> N;        // Number of observations
-  int<lower=0, upper=1> treatment[N]; // Treatment indicator (0 or 1)
+  array[N] int<lower=0, upper=1> treatment; // Treatment indicator (0 or 1)
   int<lower=1> K;        // Number of predictors (columns in X)
   // Data
   matrix[N, K] X;        // Design matrix
@@ -119,8 +119,8 @@ generated quantities {
   real ATE;
   real tau_prob_zero;
 
-  int<lower=0, upper=1> y0_zero[N];
-  int<lower=0, upper=1> y1_zero[N];
+  array[N] int<lower=0, upper=1> y0_zero;
+  array[N] int<lower=0, upper=1> y1_zero;
 
   for (n in 1:N) {
     // Linear predictors for both treatment and control

--- a/inst/stan/logit.stan
+++ b/inst/stan/logit.stan
@@ -16,7 +16,7 @@
 
 data {
   int N;                          // Number of observations
-  int<lower = 0, upper = 1> y[N]; // Outcome (binary 0 or 1)
+  array[N] int<lower = 0, upper = 1> y; // Outcome (binary 0 or 1)
   int K;                          // Number of covariates
   matrix[N, K] X;                 // Model matrix (contains predictor values)
   real mean_alpha;

--- a/inst/stan/metaanalysisnox.stan
+++ b/inst/stan/metaanalysisnox.stan
@@ -21,8 +21,8 @@
 
 data {
   int<lower=0> J;         // number of studies
-  real y[J];              // estimated lift
-  real<lower=0> sigma[J]; // standard error of lift estimates
+  array[J] real y;              // estimated lift
+  array[J] real<lower=0> sigma; // standard error of lift estimates
   int<lower=0, upper=1> run_estimation;
   real<lower=0> sd_mu;
   real mean_mu;


### PR DESCRIPTION
This PR updates the deprecated array syntax in your package's models, otherwise your package will fail to install with future versions of RStan